### PR TITLE
Add version to manifest to satisfy Home Assistant requirements

### DIFF
--- a/custom_components/escea/manifest.json
+++ b/custom_components/escea/manifest.json
@@ -2,6 +2,7 @@
   "domain": "escea",
   "name": "Escea Fires",
   "documentation": "https://github.com/snikch/climate.escea",
+  "version": "1.0.1",
   "requirements": ["escea==2.0.1"],
   "dependencies": [],
   "codeowners": ["@snikch"]


### PR DESCRIPTION
As of Home Assistant 2021.5.1, it is necessary for custom components to define a version in their manifest file. 
This change satisfies that requirement and addresses issue #7 