### PR TITLE
Replace scheduled actions with on-demand runs.

### DIFF
--- a/.github/workflows/hacsaction.yml
+++ b/.github/workflows/hacsaction.yml
@@ -3,8 +3,7 @@ name: HACS Action
 on:
   push:
   pull_request:
-  schedule:
-    - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   hacs:

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -3,8 +3,7 @@ name: Validate with hassfest
 on:
   push:
   pull_request:
-  schedule:
-    - cron:  '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   validate:


### PR DESCRIPTION
As the current actions are running every day and failing, and will continue to fail, disable the schedule -- but allow them to be run on demand. They will continue to run on pushes and pull_requests.